### PR TITLE
do not generate omitted fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## Version [1.0.1][unreleased] - (in development)
+## Version [1.1.1][unreleased] - (in development)
 - TBD
+
+## Version [1.1.0] - 2016-06-21
+- Fixed: Do not generate omitted fields
 
 ## Version [1.0.0] - 2016-04-18
 - Changed: CDA 2.0.4 - 7.0.0

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <commons-io.version>2.4</commons-io.version>
     <javapoet.version>1.1.0</javapoet.version>
     <cda.version>7.0.0</cda.version>
-    <cma.version>1.0.1</cma.version>
+    <cma.version>1.2.0</cma.version>
     <guava.version>18.0</guava.version>
     <vault.version>2.0.0</vault.version>
 

--- a/src/main/java/com/contentful/generator/Generator.java
+++ b/src/main/java/com/contentful/generator/Generator.java
@@ -144,7 +144,7 @@ public class Generator {
         .addAnnotation(annotateModel(contentType));
 
     for (CMAField field : contentType.getFields()) {
-      if (field.isDisabled()) {
+      if (field.isDisabled() || field.isOmitted()) {
         continue;
       }
 

--- a/src/test/java/com/contentful/generator/GeneratorTests.java
+++ b/src/test/java/com/contentful/generator/GeneratorTests.java
@@ -17,20 +17,20 @@
 package com.contentful.generator;
 
 import com.contentful.generator.lib.TestUtils;
-import com.contentful.java.cma.Constants;
 import com.contentful.java.cma.Constants.CMAFieldType;
 import com.contentful.java.cma.model.CMAContentType;
 import com.contentful.java.cma.model.CMAField;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.squareup.javapoet.JavaFile;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -79,7 +79,7 @@ public class GeneratorTests extends BaseTest {
     try {
       CMAField field = new CMAField().setId("fid").setType(CMAFieldType.Array);
 
-      field.setArrayItems(new HashMap(){{
+      field.setArrayItems(new HashMap() {{
         put("type", "Link");
         put("linkType", "Entry");
       }});
@@ -87,7 +87,7 @@ public class GeneratorTests extends BaseTest {
       new Generator().createFieldSpec(field, "test", "name", "ctid");
     } catch (GeneratorException e) {
       assertEquals("Field \"fid\" for content type \"ctid\" is missing link validation, "
-              + "must have content type validation.", e.getMessage());
+          + "must have content type validation.", e.getMessage());
       throw e;
     }
   }
@@ -156,10 +156,10 @@ public class GeneratorTests extends BaseTest {
     } catch (RuntimeException e) {
       Mockito.verify(printer).print("Failed to fetch content types, reason: java.io.IOException: " +
           "FAILED REQUEST: Request{method=GET, url=https://api.contentful.com/spaces/spaceid/" +
-          "content_types, tag=Request{method=GET, url=https://api.contentful.com/spaces/spaceid/" +
-          "content_types, tag=null}}\n" +
+          "content_types?limit=100, tag=Request{method=GET, url=https://api.contentful.com/spaces/" +
+          "spaceid/content_types?limit=100, tag=null}}\n" +
           "\t… Response{protocol=http/1.1, code=401, message=Unauthorized, " +
-          "url=https://api.contentful.com/spaces/spaceid/content_types}");
+          "url=https://api.contentful.com/spaces/spaceid/content_types?limit=100}");
       throw(e);
     }
   }

--- a/src/test/resources/BaseFields.java
+++ b/src/test/resources/BaseFields.java
@@ -11,6 +11,12 @@ public class BaseFields extends Resource {
   String text;
 
   @Field
+  String notDisabledField;
+
+  @Field
+  String notOmittedField;
+
+  @Field
   String symbol;
 
   @Field
@@ -33,6 +39,14 @@ public class BaseFields extends Resource {
 
   public String text() {
     return text;
+  }
+
+  public String notDisabledField() {
+    return notDisabledField;
+  }
+
+  public String notOmittedField() {
+    return notOmittedField;
   }
 
   public String symbol() {

--- a/src/test/resources/base_fields.json
+++ b/src/test/resources/base_fields.json
@@ -13,6 +13,31 @@
       "disabled": true
     },
     {
+      "name": "notDisabledField",
+      "id": "notDisabledField",
+      "type": "Text",
+      "disabled": false
+    },
+    {
+      "name": "omittedField",
+      "id": "omittedField",
+      "type": "Text",
+      "omitted": true
+    },
+    {
+      "name": "disabledAndOmittedField",
+      "id": "disabledAndOmittedField",
+      "type": "Text",
+      "disabled": true,
+      "omitted": true
+    },
+    {
+      "name": "notOmittedField",
+      "id": "notOmittedField",
+      "type": "Text",
+      "omitted": false
+    },
+    {
       "name": "symbol",
       "id": "symbol",
       "type": "Symbol"


### PR DESCRIPTION
The CMA returnes content type fields, whose `omitted` value does not get respected. Omitted fields should not appear in generated classes. 